### PR TITLE
Fix streaming accumulation for model and tool outputs

### DIFF
--- a/src/app/agent/graph.py
+++ b/src/app/agent/graph.py
@@ -1,24 +1,147 @@
 from datetime import UTC, datetime
-from typing import Dict, List, Literal, cast
- 
+import json
+from typing import Any, Dict, List, Literal, cast
+
 from langchain_core.messages import AIMessage, AIMessageChunk
 from langgraph.graph import StateGraph
 from langgraph.prebuilt import ToolNode
 from langgraph.runtime import Runtime
- 
+
 from app.agent.context import Context
 from app.agent.state import InputState, State
 from app.agent.tools import TOOLS
 from app.agent.aicore_langchain import get_openai_compatible_chat
 from app.agent.ms_nodes.history_node import load_history, write_user, write_ai
 from app.agent.utils import normalize_ai_toolcalls
- 
-from typing import Dict, List
+
 from langchain_core.runnables import RunnableConfig
-from datetime import UTC, datetime
  
 # --------- Nodos -------------
  
+def _chunk_to_text(chunk: AIMessageChunk) -> str:
+    """Best-effort extraction of textual deltas from a streamed chunk."""
+
+    content = getattr(chunk, "content", None)
+    if not content:
+        return ""
+
+    if isinstance(content, str):
+        return content
+
+    if isinstance(content, dict):
+        text = content.get("text")
+        return text or ""
+
+    # Lists of content parts (LangChain V1 structured output)
+    if isinstance(content, list):
+        pieces: List[str] = []
+        for part in content:
+            if isinstance(part, str):
+                pieces.append(part)
+            elif isinstance(part, dict):
+                txt = part.get("text") or ""
+                if isinstance(txt, str):
+                    pieces.append(txt)
+            else:
+                txt = getattr(part, "text", None) or getattr(part, "content", None)
+                if isinstance(txt, str):
+                    pieces.append(txt)
+        return "".join(pieces)
+
+    return ""
+
+
+def _coerce_tool_delta(delta: Any) -> Dict[str, Any]:
+    """Convert any tool-call fragment into a plain dict for accumulation."""
+
+    if delta is None:
+        return {}
+    if isinstance(delta, dict):
+        return {k: v for k, v in delta.items() if v is not None}
+    if hasattr(delta, "dict"):
+        try:
+            return {k: v for k, v in delta.dict(exclude_none=True).items() if v is not None}
+        except Exception:  # pragma: no cover - defensive
+            pass
+    if hasattr(delta, "model_dump"):
+        try:
+            return {k: v for k, v in delta.model_dump(exclude_none=True).items() if v is not None}
+        except Exception:  # pragma: no cover - defensive
+            pass
+    if hasattr(delta, "__dict__"):
+        return {k: v for k, v in vars(delta).items() if v is not None}
+    return {}
+
+
+def _merge_arguments(existing: Dict[str, Any], new_value: Any) -> Any:
+    """Merge streaming argument payloads (dicts or partial JSON strings)."""
+
+    if new_value is None:
+        return existing
+
+    if isinstance(new_value, dict):
+        current = existing if isinstance(existing, dict) else {}
+        current.update(new_value)
+        return current
+
+    if isinstance(new_value, str):
+        prior = existing if isinstance(existing, str) else ""
+        combined = prior + new_value
+        try:
+            return json.loads(combined)
+        except Exception:
+            # keep accumulating raw string; caller can retry on next delta
+            return combined
+
+    return new_value
+
+
+def _accumulate_tool_call(partials: Dict[str, Dict[str, Any]], delta: Dict[str, Any]) -> None:
+    """Update the partial tool-call cache with a new streamed fragment."""
+
+    if not delta:
+        return
+
+    call_id = delta.get("id") or delta.get("tool_call_id")
+
+    # OpenAI-style {"type": "function", "function": {...}}
+    function_payload = delta.get("function")
+    if isinstance(function_payload, dict):
+        if not call_id:
+            call_id = function_payload.get("id")
+        name = function_payload.get("name")
+        args = function_payload.get("arguments")
+    else:
+        name = delta.get("name")
+        args = delta.get("args")
+
+    if not call_id:
+        # use deterministic key to keep ordering stable
+        call_id = f"call_{len(partials)}"
+
+    current = partials.setdefault(call_id, {"id": call_id})
+
+    call_type = delta.get("type")
+    if call_type:
+        current["type"] = call_type
+
+    if name:
+        current["name"] = name
+
+    current_args = current.get("args")
+    merged_args = _merge_arguments(current_args, args)
+    if merged_args is not None:
+        current["args"] = merged_args
+
+    # Preserve original OpenAI shape for compatibility if present
+    if isinstance(function_payload, dict):
+        current["function"] = {
+            k: v
+            for k, v in function_payload.items()
+            if v is not None
+        }
+
+
 async def call_model(state: State, config: RunnableConfig, runtime: Runtime[Context]) -> Dict[str, List[AIMessage]]:
     chat = await get_openai_compatible_chat(
         headers=runtime.context.headers,
@@ -34,28 +157,69 @@ async def call_model(state: State, config: RunnableConfig, runtime: Runtime[Cont
  
     # ← this is the key: pass `config` (NOT runtime)
     parts: List[str] = []
-    tool_calls: List[dict] = []
-    
+    partial_tool_calls: Dict[str, Dict[str, Any]] = {}
+    last_additional_kwargs: Dict[str, Any] = {}
+    last_metadata: Dict[str, Any] = {}
+    message_id: str | None = None
+    message_name: str | None = None
+
     async for ch in model.astream(messages, config=config):
-    # === SIMPLE, VERBOSE-BUT-USEFUL LOGGING ===
-    # 1) Text delta
-        if isinstance(ch, AIMessageChunk):
-            c = getattr(ch, "content", None)
-            if isinstance(c, str) and c:
-                print(f"[STREAM Δtext] {repr(c)}")
-    
-        # 2) Newer LC normalized tool-calls (can be partial/incremental)
-        for tc in (getattr(ch, "tool_calls", None) or []):
-            print(f"[STREAM Δtool] id={tc.get('id')} name={tc.get('name')} args_delta={tc.get('args')}")
-    
-        # 3) Legacy OpenAI function_call (single tool; also incremental)
+        if not isinstance(ch, AIMessageChunk):
+            continue
+
+        delta_text = _chunk_to_text(ch)
+        if delta_text:
+            parts.append(delta_text)
+
+        for tc in getattr(ch, "tool_calls", []) or []:
+            _accumulate_tool_call(partial_tool_calls, _coerce_tool_delta(tc))
+
+        for tc in getattr(ch, "tool_call_chunks", []) or []:
+            _accumulate_tool_call(partial_tool_calls, _coerce_tool_delta(tc))
+
         fc = (getattr(ch, "additional_kwargs", {}) or {}).get("function_call")
         if fc:
-            print(f"[STREAM Δfunction_call] name={fc.get('name')} args_delta={fc.get('arguments')}")
- 
-    final_text = "".join(parts).strip()
-    return {"messages": [AIMessage(content=final_text, tool_calls=tool_calls)]}
-    #return {"messages": [AIMessage(content=final_text, tool_calls=tool_calls or None)]}
+            # function_call is always a dict with {name, arguments}
+            payload = {"type": "function", "function": fc}
+            _accumulate_tool_call(partial_tool_calls, payload)
+
+        if getattr(ch, "additional_kwargs", None):
+            last_additional_kwargs = cast(Dict[str, Any], ch.additional_kwargs)
+
+        if getattr(ch, "response_metadata", None):
+            last_metadata.update(cast(Dict[str, Any], ch.response_metadata))
+
+        if getattr(ch, "id", None):
+            message_id = cast(str, ch.id)
+
+        if getattr(ch, "name", None):
+            message_name = cast(str, ch.name)
+
+    final_text = "".join(parts)
+
+    tool_calls: List[Dict[str, Any]] = []
+    for call in partial_tool_calls.values():
+        cleaned = dict(call)
+        raw_args = cleaned.get("args")
+        if isinstance(raw_args, str):
+            try:
+                cleaned["args"] = json.loads(raw_args)
+            except Exception:
+                # leave as string if it isn't valid JSON yet
+                pass
+        tool_calls.append(cleaned)
+
+    ai_message = AIMessage(
+        content=final_text,
+        tool_calls=tool_calls or None,
+        additional_kwargs=last_additional_kwargs,
+        response_metadata=last_metadata,
+        id=message_id,
+        name=message_name,
+    )
+
+    normalized = normalize_ai_toolcalls(ai_message)
+    return {"messages": [normalized]}
  
 # ------------------ Aristas ----------------------
  

--- a/src/app/routes/agent.py
+++ b/src/app/routes/agent.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
+import json
+import time
+from typing import Any, AsyncIterator, Dict, List, Optional
+
 from fastapi import APIRouter, Depends
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
-from typing import Any, Dict, Optional
 
 from langchain_core.messages import HumanMessage
+from openai import APIConnectionError
 
 from qgdiag_lib_arquitectura.schemas.response_body import ResponseBody
 from qgdiag_lib_arquitectura.utilities.logging_conf import CustomLogger
@@ -13,33 +19,12 @@ from qgdiag_lib_arquitectura.exceptions.types import (
     ForbiddenException,
     InternalServerErrorException,
 )
-from openai import APIConnectionError
 
 from app.settings import settings
 from app.agent.graph import graph
 from app.agent.context import Context
 from app.agent.state import State
 from app.agent.utils import get_message_text
-
-# streaming addtions
-
-from fastapi import Response
-from fastapi.responses import StreamingResponse
-from datetime import datetime, timezone
-import asyncio
-import json
-from typing import AsyncIterator
-
-
-# app/routes/agent.py (add this route)
-from fastapi import Depends
-from fastapi.responses import StreamingResponse
-from pydantic import BaseModel
-from typing import Dict, Optional, AsyncIterator
-import asyncio, json, time
-
-from qgdiag_lib_arquitectura.security.authentication import get_authenticated_headers
-from app.settings import settings
 from app.agent.aicore_langchain import get_openai_compatible_chat
 
 router = APIRouter(prefix="/agent", tags=["agent"])
@@ -104,8 +89,9 @@ async def react_run_endpoint(
         raise InternalServerErrorException(str(e)) from e
 
 
-# --- Helper: safe string extraction from LC content ----
-def _as_text(content) -> str:
+# --- Helper utilities for streaming payloads ----
+
+def _as_text(content: Any) -> str:
     if content is None:
         return ""
     if isinstance(content, str):
@@ -124,6 +110,84 @@ def _as_text(content) -> str:
     except Exception:
         return str(content)
 
+
+def _as_dict(obj: Any) -> Dict[str, Any]:
+    if obj is None:
+        return {}
+    if isinstance(obj, dict):
+        return {k: v for k, v in obj.items() if v is not None}
+    if hasattr(obj, "dict"):
+        try:
+            return {k: v for k, v in obj.dict(exclude_none=True).items()}
+        except Exception:  # pragma: no cover - defensive
+            pass
+    if hasattr(obj, "model_dump"):
+        try:
+            return {k: v for k, v in obj.model_dump(exclude_none=True).items()}
+        except Exception:  # pragma: no cover - defensive
+            pass
+    if hasattr(obj, "__dict__"):
+        return {k: v for k, v in vars(obj).items() if v is not None and not k.startswith("_")}
+    return {}
+
+
+def _chunk_text(chunk: Any) -> str:
+    if chunk is None:
+        return ""
+    if hasattr(chunk, "content"):
+        return _as_text(getattr(chunk, "content"))
+    chunk_dict = _as_dict(chunk)
+    if "content" in chunk_dict:
+        return _as_text(chunk_dict.get("content"))
+    return ""
+
+
+def _chunk_tool_deltas(chunk: Any) -> List[Dict[str, Any]]:
+    deltas: List[Dict[str, Any]] = []
+    sources: List[Any] = []
+
+    if chunk is not None:
+        sources.append(getattr(chunk, "tool_call_chunks", None))
+        sources.append(getattr(chunk, "tool_calls", None))
+
+    chunk_dict = _as_dict(chunk)
+    sources.append(chunk_dict.get("tool_call_chunks"))
+    sources.append(chunk_dict.get("tool_calls"))
+
+    for maybe_list in sources:
+        if not maybe_list:
+            continue
+        for item in maybe_list:
+            coerced = _as_dict(item)
+            if coerced:
+                deltas.append(coerced)
+
+    return deltas
+
+
+def _chunk_function_call(chunk: Any) -> Optional[Dict[str, Any]]:
+    candidate = None
+    if chunk is not None and hasattr(chunk, "additional_kwargs"):
+        candidate = getattr(chunk, "additional_kwargs")
+
+    if not isinstance(candidate, dict):
+        chunk_dict = _as_dict(chunk)
+        if not isinstance(candidate, dict):
+            candidate = chunk_dict.get("additional_kwargs")
+        if not candidate and "function_call" in chunk_dict:
+            fc = chunk_dict.get("function_call")
+            if fc:
+                return _as_dict(fc)
+
+    if isinstance(candidate, dict):
+        fc = candidate.get("function_call")
+        if fc:
+            if isinstance(fc, str):
+                return {"arguments": fc}
+            return _as_dict(fc)
+
+    return None
+
 def _now_iso():
     return datetime.now(timezone.utc).isoformat()
 
@@ -140,59 +204,32 @@ def _event_to_wire(ev: dict) -> dict:
     data = ev.get("data") or {}
     ts = _now_iso()
 
-    
+
     if ev_type == "on_chat_model_stream":
-        chunk = data.get("chunk")
-        delta = ""
+        chunk = data.get("chunk") or data
+        delta_text = _chunk_text(chunk)
+        tool_deltas = _chunk_tool_deltas(chunk)
+        function_delta = _chunk_function_call(chunk)
+        response_meta = None
+        if chunk is not None and hasattr(chunk, "response_metadata"):
+            response_meta = getattr(chunk, "response_metadata")
+        if not isinstance(response_meta, dict):
+            response_meta = _as_dict(data.get("response_metadata"))
 
-        # chunk can be an object (AIMessageChunk) or a dict
-        # 1) Try attribute access
-        if chunk is not None and hasattr(chunk, "content"):
-            c = chunk.content
-            # content can be str or list of content parts
-            if isinstance(c, str):
-                delta = c
-            elif isinstance(c, list):
-                # content parts may be dicts or objects with .get/.text
-                parts = []
-                for p in c:
-                    if isinstance(p, str):
-                        parts.append(p)
-                    elif isinstance(p, dict):
-                        parts.append(p.get("text") or "")
-                    else:
-                        # object with .text or .content?
-                        txt = getattr(p, "text", None) or getattr(p, "content", None)
-                        if isinstance(txt, str):
-                            parts.append(txt)
-                delta = "".join(parts)
-
-        # 2) If chunk is a dict-like
-        if not delta and isinstance(chunk, dict):
-            c = chunk.get("content")
-            if isinstance(c, str):
-                delta = c
-            elif isinstance(c, list):
-                parts = []
-                for p in c:
-                    if isinstance(p, str):
-                        parts.append(p)
-                    elif isinstance(p, dict):
-                        parts.append(p.get("text") or "")
-                delta = "".join(parts)
-
-        # 3) Final fallback: some providers put text directly in data["content"]
-        if not delta and "content" in data:
-            c = data["content"]
-            if isinstance(c, str):
-                delta = c
+        payload: Dict[str, Any] = {"delta": delta_text or "", "accumulated": False}
+        if tool_deltas:
+            payload["tool_calls_delta"] = tool_deltas
+        if function_delta:
+            payload["function_call_delta"] = function_delta
+        if response_meta:
+            payload["response_metadata"] = response_meta
 
         return {
             "type": "token",
             "ts": ts,
             "run_id": run_id,
             "node": node_name,
-            "data": {"delta": delta, "accumulated": False},
+            "data": payload,
         }
 
     # Tool lifecycle
@@ -242,13 +279,20 @@ def _event_to_wire(ev: dict) -> dict:
     # Graph end
     if ev_type == "on_graph_end":
         final_text = None
+        final_tool_calls: List[Dict[str, Any]] = []
         out = data.get("output") or {}
-        # Try to pull final text if available
+
         msgs = out.get("messages")
         if isinstance(msgs, list) and msgs:
-            # last message content as text
             last = msgs[-1]
-            final_text = _as_text(getattr(last, "content", None) or getattr(last, "text", None) or out.get("final_text"))
+            last_dict = _as_dict(last)
+            final_text = _as_text(last_dict.get("content")) or _as_text(last_dict.get("text")) or _as_text(out.get("final_text"))
+            tool_call_items = last_dict.get("tool_calls") or []
+            if isinstance(tool_call_items, list):
+                for item in tool_call_items:
+                    coerced = _as_dict(item)
+                    if coerced:
+                        final_tool_calls.append(coerced)
         else:
             final_text = _as_text(out.get("final_text"))
 
@@ -257,7 +301,7 @@ def _event_to_wire(ev: dict) -> dict:
             "ts": ts,
             "run_id": run_id,
             "node": node_name,
-            "data": {"final_text": final_text},
+            "data": {"final_text": final_text, "tool_calls": final_tool_calls or None},
         }
 
     # Fallback: info
@@ -310,12 +354,10 @@ async def react_stream_endpoint(
                     recursion_limit=4,
                 ):
                     log.info(f"GRAPH EVENT RECEIVED: type={ev['event']}, node={ev.get('name')}")
-                    line = _event_to_wire(ev)
-                    if ev["event"] == "on_chat_model_stream":
-                        wire_event = _event_to_wire(ev)
-                        yield _json_line(wire_event)
-
-                    yield _json_line(line).encode("utf-8")
+                    wire_event = _event_to_wire(ev)
+                    if not wire_event:
+                        continue
+                    yield _json_line(wire_event).encode("utf-8")
 
             except Exception as e:
                 # Emit error and stop
@@ -325,13 +367,6 @@ async def react_stream_endpoint(
                     "data": {"message": str(e)}
                 }).encode("utf-8")
                 return
-
-            # Ensure final marker
-            yield _json_line({
-                "type": "graph_end",
-                "ts": _now_iso(),
-                "data": {"final_text": None}
-            }).encode("utf-8")
 
         # Headers that play nice with gateways
         headers_out = {


### PR DESCRIPTION
## Summary
- accumulate streamed text and tool-call fragments inside the LangGraph model node so the final AIMessage contains both
- normalize streamed NDJSON responses to expose text, tool-call deltas, and finish metadata without duplicate events or synthetic graph_end markers

## Testing
- `PYTHONPATH=src pytest` *(fails: missing app.* packages in repo and httpx dependency required by starlette.testclient)*

------
https://chatgpt.com/codex/tasks/task_e_68ccf93741008325bbf34f90ce5d4f3d